### PR TITLE
Add setting to open files in existing leaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Text-based GTD in Obsidian.
 
 **Date format**: Customise the date format. Uses luxon under the hood. See [their documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for supported tokens. Defaults to `yyyy-MM-dd`.
 
+**Open files in a new leaf**: When enabled, files opened from within the plugin will open in a new leaf rather than replacing the currently opened file.
+
 ### Screenshots
 ![](./assets/today.png)
 ![](./assets/scheduled.png)

--- a/main.ts
+++ b/main.ts
@@ -26,7 +26,11 @@ export default class TodoPlugin extends Plugin {
         todos: todos,
         openFile: (filePath: string) => {
           const file = this.app.vault.getAbstractFileByPath(filePath) as TFile;
-          this.app.workspace.splitActiveLeaf().openFile(file);
+          if (this.settings.openFilesInNewLeaf && this.app.workspace.getActiveFile()) {
+            this.app.workspace.splitActiveLeaf().openFile(file);
+          } else {
+            this.app.workspace.getUnpinnedLeaf().openFile(file);
+          }
         },
         toggleTodo: (todo: TodoItem, newStatus: TodoItemStatus) => {
           this.todoIndex.setStatus(todo, newStatus);

--- a/model/TodoPluginSettings.ts
+++ b/model/TodoPluginSettings.ts
@@ -1,9 +1,11 @@
 export interface TodoPluginSettings {
   dateFormat: string;
   dateTagFormat: string;
+  openFilesInNewLeaf: boolean;
 }
 
 export const DEFAULT_SETTINGS: TodoPluginSettings = {
   dateFormat: 'yyyy-MM-dd',
   dateTagFormat: '#%date%',
+  openFilesInNewLeaf: true,
 };

--- a/ui/SettingsTab.ts
+++ b/ui/SettingsTab.ts
@@ -66,6 +66,18 @@ export class SettingsTab extends PluginSettingTab {
           this.plugin.updateSettings({ ...currentSettings, dateFormat });
         }),
       );
+
+    new Setting(containerEl)
+      .setName('Open files in a new leaf')
+      .setDesc(
+        'If enabled, when opening the file containing a TODO that file will open in a new leaf. If disabled, it will replace the file that you currently have open.',
+      )
+      .addToggle((toggle) => {
+        toggle.setValue(currentSettings.openFilesInNewLeaf);
+        toggle.onChange(async (openFilesInNewLeaf) => {
+          this.plugin.updateSettings({ ...currentSettings, openFilesInNewLeaf });
+        });
+      });
   }
 
   private dateTagFormatDescription(error?: string): DocumentFragment {


### PR DESCRIPTION
I’ve added a setting tab for this plugin to Obsidian’s settings with the option to open a todo’s file in the existing leaf instead. Behavior when set to open in a new leaf (default) hasn’t changed, with one exception: if there is no file open, opening one from a todo will replace the “No file is open” leaf instead of splitting it. This adds #14.