### PR TITLE
feat(commands): Add create todo command

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -23,6 +23,14 @@ export default class TodoPlugin extends Plugin {
     this.settings = Object.assign(DEFAULT_SETTINGS, (await this.loadData()) ?? {});
     this.dateFormatter = new DateFormatter(this.settings.dateFormat);
     this.addSettingTab(new SettingsTab(this.app, this));
+    
+    this.addCommand({
+      id: 'create-todo-list',
+      name: 'Todo List',
+      callback: () => {
+        console.log('test);
+      },
+    });
 
     this.registerView(VIEW_TYPE_TODO, (leaf: WorkspaceLeaf) => {
       const todos: TodoItem[] = [];

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginManifest, TFile, WorkspaceLeaf } from 'obsidian';
+import { App, Plugin, PluginManifest, TFile, WorkspaceLeaf, Editor, MarkdownView } from 'obsidian';
 import { VIEW_TYPE_TODO } from './constants';
 import { TodoItemView, TodoItemViewProps } from './ui/TodoItemView';
 import { TodoItem, TodoItemStatus } from './model/TodoItem';
@@ -23,12 +23,14 @@ export default class TodoPlugin extends Plugin {
     this.settings = Object.assign(DEFAULT_SETTINGS, (await this.loadData()) ?? {});
     this.dateFormatter = new DateFormatter(this.settings.dateFormat);
     this.addSettingTab(new SettingsTab(this.app, this));
-    
+
     this.addCommand({
       id: 'create-todo-list',
-      name: 'Todo List',
-      callback: () => {
-        console.log('test);
+      name: '☐ Create',
+      editorCallback: (editor: Editor) => {
+        let originVal: string = editor.getValue();
+        originVal += '- [ ] ';
+        editor.setValue(originVal);
       },
     });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "obsidian-plugin-todo",
-  "name": "Obsidian TODO | Text-based GTD",
+  "name": "TODO",
   "version": "0.2.7",
   "minAppVersion": "0.11.0",
   "description": "Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.",


### PR DESCRIPTION
### What this PR does

- Adds a create todo command to Obsidian Command Palette

### Why is this needed?

I like using slash command from Craft.do to create a todo list, I wanted to have a similar experience in Obsidian.

`You need this PR update and slash commands core plugin installed to reach the state I put below.`

This is how it looks at Craft:
<img width="376" alt="Screenshot 2022-08-17 at 12 07 51" src="https://user-images.githubusercontent.com/1593488/185093227-0c2898ed-36ab-46ed-b03d-762ef0d35593.png">

It looks like this at Obsidian with my change:
<img width="367" alt="Screenshot 2022-08-17 at 12 08 58" src="https://user-images.githubusercontent.com/1593488/185093433-91c1c15d-acc5-4dbb-9fa8-7d951d5e40d0.png">

 