### PR TITLE
Regex matching for paths to include, regex for "someday" lines and a regex to hide TODOs without completing them.

### DIFF
--- a/DemoVault/Daily Notes/2022-02-11.md
+++ b/DemoVault/Daily Notes/2022-02-11.md
@@ -1,3 +1,4 @@
 - [ ] Do something on the date of this daily note
 - [ ] Do something in 2099 #2099-01-01
 - [ ] Do something, some day #someday
+- [ ] Do something, never #never

--- a/DemoVault/TODO.md
+++ b/DemoVault/TODO.md
@@ -5,3 +5,4 @@
 - [ ] Do today #2022-02-09
 - [ ] Read "Meditations" by Marcus Aurelius #someday
 - [ ] Check out "The Queen's Gambit" on [[Netflix]]
+- [ ] This task is super important, i'll do it this week #never

--- a/model/TodoParser.ts
+++ b/model/TodoParser.ts
@@ -2,37 +2,73 @@ import { DateParser } from '../util/DateParser';
 import { TodoItem, TodoItemStatus } from '../model/TodoItem';
 import { DateTime } from 'luxon';
 import { extractDueDateFromDailyNotesFile } from '../util/DailyNoteParser';
+import { TextPatternParser } from 'util/TextPatternParser';
 
 export class TodoParser {
   private dateParser: DateParser;
+  private hideParser: TextPatternParser;
+  private somedayParser: TextPatternParser;
+  private includeCompleted: boolean;
+  private folderParser: TextPatternParser;
 
-  constructor(dateParser: DateParser) {
+
+  constructor(dateParser: DateParser, somedayParser: TextPatternParser, hideParser: TextPatternParser, folderParser: TextPatternParser, includeCompleted: boolean = false) {
     this.dateParser = dateParser;
+    this.hideParser = hideParser;
+    this.somedayParser = somedayParser;
+    this.includeCompleted = includeCompleted;
+    this.folderParser = folderParser;
   }
 
-  async parseTasks(filePath: string, fileContents: string): Promise<TodoItem[]> {
+  public async parseTasks(filePath: string, fileContents: string): Promise<TodoItem[]> {
+    // skip file if it doesn't match pattern
+    if (!this.folderParser.HasMatch(filePath)) {
+      return [];
+    }
+
     const pattern = /(-|\*) \[(\s|x)?\]\s(.*)/g;
-    return [...fileContents.matchAll(pattern)].map((task) => this.parseTask(filePath, task));
+    return [...fileContents.matchAll(pattern)].map((task) => this.parseTask(filePath, task)).filter((task) => task != null);
   }
 
-  private parseTask(filePath: string, entry: RegExpMatchArray): TodoItem {
+  private parseTask(filePath: string, entry: RegExpMatchArray): TodoItem | null {
     const todoItemOffset = 2; // Strip off `-|* `
     const status = entry[2] === 'x' ? TodoItemStatus.Done : TodoItemStatus.Todo;
+
+    // caught todos are filtered at the end, just stop parsing them now isntead
+    if (status == TodoItemStatus.Done && !this.includeCompleted) {
+      return null;
+    }
+
     const description = entry[3];
+
+    if (this.hideParser.HasMatch(description)) {
+      return null;
+    }
+
+    if (this.somedayParser.HasMatch(description)) {
+      // don't parse dates for someday tasks
+      return new TodoItem(
+        status,
+        description,
+        true,
+        filePath,
+        (entry.index ?? 0) + todoItemOffset,
+        entry[0].length - todoItemOffset,
+        undefined
+      );
+    }
 
     const actionDate = this.parseDueDate(description, filePath);
     const descriptionWithoutDate = this.dateParser.removeDate(description);
-    const somedayPattern = /#(someday)/g;
-    const isSomedayMaybeTask = description.match(somedayPattern) != null;
 
     return new TodoItem(
       status,
       descriptionWithoutDate,
-      isSomedayMaybeTask,
+      false,
       filePath,
       (entry.index ?? 0) + todoItemOffset,
       entry[0].length - todoItemOffset,
-      !isSomedayMaybeTask ? actionDate : undefined,
+      actionDate
     );
   }
 

--- a/model/TodoPluginSettings.ts
+++ b/model/TodoPluginSettings.ts
@@ -2,10 +2,25 @@ export interface TodoPluginSettings {
   dateFormat: string;
   dateTagFormat: string;
   openFilesInNewLeaf: boolean;
+  /**
+     * RegExp pattern or array of RegExp patterns that will classify a todo as a 'someday'
+     */
+  somedayPatterns: string | string[];
+  /**
+   * RegExp pattern or array of RegExp patterns that prevent the todo from being indexed
+   */
+  hidePatterns: string | string[];
+  /**
+   * Only files matching these pattern(s) will be indexed
+   */
+  includeFolderPatterns: string | string[];
 }
 
 export const DEFAULT_SETTINGS: TodoPluginSettings = {
   dateFormat: 'yyyy-MM-dd',
-  dateTagFormat: '#%date%',
   openFilesInNewLeaf: true,
+  dateTagFormat: '#%date%',
+  somedayPatterns: '#someday',
+  hidePatterns: ['#never', '#surpress'],
+  includeFolderPatterns: '.*'
 };

--- a/util/TextPatternParser.test.ts
+++ b/util/TextPatternParser.test.ts
@@ -1,0 +1,81 @@
+import { TextPatternParser } from './TextPatternParser';
+
+type PatternTestNames = 'single' | 'array' | 'null' | 'empty' | 'emptyArray';
+type TestStringNames = 'none' | 'test' | 'test2' | 'empty' | 'null';
+
+type ExpectedTestResults = {
+    [P in PatternTestNames]: {
+        [T in TestStringNames]: boolean;
+    };
+}
+
+const PatternTests: {[P in PatternTestNames]: string | string[] | undefined | null} = {
+    single: '#test',
+    empty: '',
+    array: ['#test', '#another_test', '',],
+    emptyArray: [],
+    null: null
+}
+
+const StringTests: {[T in TestStringNames]: string} = {
+    none: 'This is a test string without any defined matches #notamatch',
+    test: 'This is a test string with #test',
+    test2: 'This string contains #another_test',
+    empty: '',
+    null: null
+}
+
+const TestsToRun: ExpectedTestResults = {
+    single: {
+        none: false,
+        test: true,
+        test2: false,
+        empty: false,
+        null: false
+    },
+    array: {
+        none: false,
+        test: true,
+        test2: true,
+        empty: false,
+        null: false
+    },
+    null: {
+        none: false,
+        test: false,
+        test2: false,
+        empty: false,
+        null: false
+    },
+    empty: {
+        none: false,
+        test: false,
+        test2: false,
+        empty: false,
+        null: false
+    },
+    emptyArray: {
+        none: false,
+        test: false,
+        test2: false,
+        empty: false,
+        null: false
+    }
+};
+
+describe('TextTagParser Tests', () => {
+    Object.keys(TestsToRun).forEach((patternName) => {
+        Object.keys(StringTests).forEach((testStringName) => {
+            const pn = patternName as PatternTestNames;
+            const sn = testStringName as TestStringNames;
+            test(
+                `testing pattern ${patternName} with test string ${testStringName} - should be - ${TestsToRun[pn][sn]}`,
+                () => {
+                    const parser = new TextPatternParser(PatternTests[pn]);
+                    const result = parser.HasMatch(StringTests[sn]);
+                    expect(result).toEqual(TestsToRun[pn][sn]);
+                }
+            );
+        });
+    });
+});

--- a/util/TextPatternParser.ts
+++ b/util/TextPatternParser.ts
@@ -1,0 +1,59 @@
+export class TextPatternParser {
+  private readonly _regExps: RegExp | RegExp[] | null;
+  private readonly _checkFunc: (source: string) => boolean;
+
+  constructor(patternsToMatch: string | string[]) {
+    // setup hide tags
+    this._regExps = this.getRegExps(patternsToMatch);
+    this._checkFunc = this.getCheckFunc(this._regExps);
+  }
+
+  public HasMatch(source: string): boolean {
+    return this._checkFunc(source);
+  }
+
+  private getCheckFunc(regExprs: RegExp | RegExp[] | null) {
+    if (regExprs == null) {
+      return (source: string) => false;
+    }
+
+    if (Array.isArray(regExprs)) {
+      return (source: string) => regExprs.some((regExpr) => regExpr.test(source));
+    }
+
+    return (source: string) => regExprs.test(source);
+  }
+
+  /**
+   * Filters out bad values and converts strings to regExps
+   * @param tagSource 
+   * @returns 
+   */  
+  private getRegExps(tagSource: string | string[]): RegExp | RegExp[] | null {
+    if (tagSource == null || tagSource == undefined || tagSource.length == 0) {
+      return null;
+    }
+
+    const whiteSpaceOnly = /^\s*$/;
+
+    if (Array.isArray(tagSource)) {
+      // filter empty searches and values from the array
+      tagSource = tagSource.filter(text => text.length > 0 && !whiteSpaceOnly.test(text));
+
+      switch (true) {
+        case tagSource.length == 0:
+          return null;
+        case tagSource.length == 1:
+          return new RegExp(tagSource[0]);
+        default:
+          return tagSource.map((tag) => new RegExp(tag));
+      }
+    } 
+
+    if (!whiteSpaceOnly.test(tagSource)) {
+      return new RegExp(tagSource);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
- Added patterns matching for 'someday' in place of fixed value.

- Added Pattern matching to hide individual TODOs

- Added Pattern matching for the folder paths allowed to be indexed.

- Added new parser to handle the json => regex patterns

- Added options in settings for each of these

- For indexing the entire vault, moved the TodoParser initialisation out so it only gets created once.